### PR TITLE
添加Mozilla Firefox浏览器插件支持

### DIFF
--- a/content.js
+++ b/content.js
@@ -4,6 +4,9 @@
 (function () {
 'use strict';
 
+// ─── §0. Cross-browser API normalization (Firefox/Chrome/Edge) ─
+const _browser = typeof browser !== 'undefined' ? browser : chrome;
+
 // ─── §1. Entry Guard ──────────────────────────────────────
 if (window.parent !== window) return;
 if (!/zhjwxk|zhjw\.cic|webvpn/.test(location.hostname)) return;

--- a/manifest.json
+++ b/manifest.json
@@ -4,6 +4,10 @@
   "short_name": "NextTHUxk",
   "version": "1.2.0",
   "description": "下一代选课 - 基于 AI 决策与现代双栏 UI 的选课无感辅助系统。",
+  "data_collection_permissions": {
+    "default": "never",
+    "new_install": "never"
+  },
   "permissions": ["activeTab", "storage"],
   "host_permissions": [
     "https://api.github.com/*",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "NextTHUxk",
   "short_name": "NextTHUxk",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "下一代选课 - 基于 AI 决策与现代双栏 UI 的选课无感辅助系统。",
   "permissions": ["activeTab", "storage"],
   "host_permissions": [
@@ -25,6 +25,12 @@
     "run_at": "document_idle",
     "all_frames": true
   }],
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "nextthuxk@smartthise.github.io",
+      "strict_min_version": "115.0"
+    }
+  },
   "action": {
     "default_popup": "popup.html",
     "default_title": "NextTHUxk"

--- a/popup.js
+++ b/popup.js
@@ -1,3 +1,6 @@
+// Cross-browser namespace normalization (Firefox/Chrome/Edge)
+const _browser = typeof browser !== 'undefined' ? browser : chrome;
+
 const statusEl = document.getElementById('status');
 const launchBtn = document.getElementById('launch');
 


### PR DESCRIPTION
- 完成了对Firefox浏览器的插件支持。
- 完成了对Firefox浏览器的测试（Firefox version 151.0.1 on Linux），对Edge/Chrome环境是否有影响还需测试。

*需要注意的是，由于Firefox浏览器的安全政策，目前仅可以通过临时挂载方式安装插件。*
如果需要让其作为正式插件上线，需要取得Firefox Add-ons Developer Hub (https://addons.mozilla.org/developers/) 签名。