### PR TITLE
修复：通过 WebVPN 加载课程数据

### DIFF
--- a/content.js
+++ b/content.js
@@ -20,8 +20,18 @@ console.log(TAG, 'loading on', location.href);
 
 // ─── Init Config State ────────────────────────────────────────
 state.SEM = (location.href.match(/p_xnxq=([^&]+)/) || ['', ''])[1];
-state.BASE = location.origin;
-state.isZhjwxk = location.hostname === 'zhjwxk.cic.tsinghua.edu.cn';
+
+// WebVPN embeds the upstream host in the pathname, for example:
+// /http/<encoded-host>/xkBks.vxkBksXkbBs.do?m=main
+// Preserve that prefix for every subsequent endpoint request.
+const _webvpn = location.hostname === 'webvpn.tsinghua.edu.cn';
+const _xkPathAt = location.pathname.search(/\/(?:xkBks|jhBks|js\.)/);
+const _webvpnPrefix = _webvpn && _xkPathAt >= 0
+  ? location.pathname.slice(0, _xkPathAt)
+  : '';
+state.BASE = location.origin + _webvpnPrefix;
+state.isZhjwxk = location.hostname === 'zhjwxk.cic.tsinghua.edu.cn'
+  || (_webvpn && /\/xkBks\./.test(location.pathname));
 state.isZhjw = location.hostname === 'zhjw.cic.tsinghua.edu.cn';
 
 // ─── Load CSS ─────────────────────────────────────────────────


### PR DESCRIPTION
## 修改内容

- 构造接口地址时，保留 WebVPN 的 `/http/<encoded-host>` 路径前缀
- 当 WebVPN 页面路径包含 `xkBks.*` 时，正确识别为本科选课系统
- 保持直连 `zhjwxk.cic.tsinghua.edu.cn` 时的原有行为不变

## 问题原因

WebVPN 页面中，`location.origin` 只有 `https://webvpn.tsinghua.edu.cn`，被编码的上游站点实际位于 `location.pathname` 中。原代码只使用 `location.origin` 作为 `state.BASE`，导致后续请求丢失 `/http/<encoded-host>` 前缀，被发送到错误的 WebVPN 根路径。

此外，原来的 `state.isZhjwxk` 只判断 hostname。WebVPN 页面会被识别为非选课系统，使 `fetchCourseCatalog()` 直接返回空数组。

## 验证

- 通过 `node --check content.js` 语法检查
- 通过 `git diff --check` 检查
- 使用形如 `/http/<encoded-host>/xkBks.vxkBksXkbBs.do?m=main` 的 WebVPN 地址验证了路径前缀提取结果

Closes #21