### PR TITLE
功能：点击课表课程定位到左侧课程卡片

### DIFF
--- a/content.css
+++ b/content.css
@@ -479,6 +479,17 @@
 .nx-tt td.nx-s { background: rgba(255,255,255,.75); backdrop-filter: saturate(160%) blur(12px); -webkit-backdrop-filter: saturate(160%) blur(12px); color: var(--nx-ink); font-weight: 600; box-shadow: inset 0 1px 0 rgba(255,255,255,.95), inset 0 0 0 1px rgba(47,107,255,.25); }
 .nx-tt td.nx-c { background: rgba(255,255,255,.75); backdrop-filter: saturate(160%) blur(12px); -webkit-backdrop-filter: saturate(160%) blur(12px); color: var(--nx-red); box-shadow: inset 0 1px 0 rgba(255,255,255,.95), inset 0 0 0 1px rgba(238,77,77,.3); }
 .nx-tt-cell { position: relative; }
+.nx-tt-jump { cursor: pointer; border-radius: 8px; transition: background .15s, transform .15s; }
+.nx-tt-jump:hover { background: rgba(47,107,255,.08); transform: translateY(-1px); }
+
+.nx-card.nx-jump-target {
+  animation: nx-jump-pulse 1.8s ease-out;
+  box-shadow: inset 0 0 0 2px var(--nx-accent), var(--nx-glass-edge), 0 12px 36px rgba(47,107,255,.22);
+}
+@keyframes nx-jump-pulse {
+  0%, 35% { background: rgba(47,107,255,.14); }
+  100% { background: var(--nx-glass); }
+}
 .nx-tt-text { display: block; font-size: 10px; line-height: 1.3; word-break: break-all; }
 .nx-tt-line { display: flex; flex-direction: column; align-items: center; gap: 2px; margin-bottom: 3px; }
 .nx-tt-line:last-child { margin-bottom: 0; }

--- a/src/render.js
+++ b/src/render.js
@@ -123,7 +123,7 @@ NX.courseCardHtml = function (c, ctx) {
         '<button class="nx-select-btn" data-code="' + esc(c.code) + '" data-seq="' + esc(c.seq || '0') + '" style="background:var(--nx-glass);color:var(--nx-ink-soft);box-shadow:inset 0 1px 0 rgba(255,255,255,.9),inset 0 0 0 1px var(--nx-line)">排队选课</button>' +
         '<button class="nx-stage-btn nx-add-stage" data-code="' + esc(c.code) + '" data-seq="' + esc(c.seq || '0') + '"' + (inStage ? ' disabled' : '') + '>' + (inStage ? '已暂存' : '暂存') + '</button>';
     }
-    return '<div class="nx-card' + (c.selected ? ' nx-selected' : '') + '" data-code="' + esc(c.code) + '" data-tid="' + esc(c.teacherId || '') + '">' +
+    return '<div class="nx-card' + (c.selected ? ' nx-selected' : '') + '" data-code="' + esc(c.code) + '" data-seq="' + esc(c.seq || '0') + '" data-tid="' + esc(c.teacherId || '') + '">' +
       '<div class="nx-card-head"><span class="nx-card-name">' + esc(c.name) + '</span>' + NX.tbBadgeHtml(c) + '<span class="nx-card-credit">' + c.credits + '学分</span></div>' +
       '<div style="font-size:11px;color:#9aa1ac;margin-bottom:3px">' + esc(c.code) + (c.seq ? ' · ' + esc(c.seq) + '课序' : '') + '</div>' +
       '<div class="nx-tags">' + tags.join('') + '</div>' +
@@ -357,7 +357,7 @@ NX.renderPreviewTT = function (courses, label) {
         const btns = items.map(it => '<span class="nx-tt-rm" data-code="' + esc(it.code) + '" data-seq="' + esc(it.seq) + '" title="移除 ' + esc(it.label) + '">✕</span>').join('');
         const linesHtml = items.map(it => {
           const probHtml = it.probLabel ? '<span class="nx-tt-prob" style="background:' + it.probBgColor + ';color:' + it.color + '">' + it.probLabel + '</span>' : '';
-          return '<div class="nx-tt-line"><span class="nx-tt-text">' + esc(it.label) + '</span>' + probHtml + '</div>';
+          return '<div class="nx-tt-line nx-tt-jump" data-code="' + esc(it.code) + '" data-seq="' + esc(it.seq) + '" title="在左侧课程列表中查看"><span class="nx-tt-text">' + esc(it.label) + '</span>' + probHtml + '</div>';
         }).join('');
         let cellClass = isC ? 'nx-c' : 'nx-s';
         let cellStyle = '';
@@ -385,8 +385,51 @@ NX.renderPreviewTT = function (courses, label) {
   el.querySelectorAll('.nx-tt-rm').forEach(btn => {
     btn.onclick = () => handlePreviewRemove(btn.dataset.code, btn.dataset.seq);
   });
+  el.querySelectorAll('.nx-tt-jump').forEach(line => {
+    line.onclick = () => NX.jumpToCourse(line.dataset.code, line.dataset.seq);
+  });
   el.querySelectorAll('.nx-tt-undet').forEach(chip => {
     chip.onclick = () => handlePreviewRemove(chip.dataset.code, chip.dataset.seq);
+  });
+};
+
+// 从课表预览定位到左侧课程列表。重置会隐藏目标课程的筛选条件，
+// 用课程号搜索后精确滚动到对应课序号。
+NX.jumpToCourse = function (code, seq) {
+  const { state } = NX;
+  const $ = state.$;
+  const course = NX.getCourse(code, seq);
+  const search = $('nextthuxk-search');
+  const list = $('nextthuxk-list');
+  if (!course || !search || !list) return;
+
+  state.activeGroup = null;
+  state.shadow.querySelectorAll('.nx-chip').forEach(chip => {
+    chip.classList.toggle('on', chip.dataset.f === 'all');
+  });
+  [
+    'nx-filter-credits', 'nx-filter-day', 'nx-filter-period',
+    'nx-filter-conflict', 'nx-filter-reviews', 'nx-sort-by',
+    'nx-filter-tongshi', 'nx-filter-feature', 'nx-filter-grade-filter',
+    'nx-filter-bksrem', 'nx-filter-yjsrem'
+  ].forEach(id => { const node = $(id); if (node) node.value = ''; });
+  const note = $('nx-filter-xknote');
+  if (note) note.value = '';
+
+  search.value = course.code;
+  NX.filterCourses();
+  list.scrollTop = 0;
+
+  requestAnimationFrame(() => {
+    const target = [...list.querySelectorAll('.nx-card')].find(card =>
+      card.dataset.code === String(code) &&
+      String(card.dataset.seq || '0') === String(seq || '0')
+    );
+    if (!target) return;
+    target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    target.classList.add('nx-jump-target');
+    setTimeout(() => target.classList.remove('nx-jump-target'), 1800);
+    search.focus({ preventScroll: true });
   });
 };
 


### PR DESCRIPTION
## 修改内容

- 课表预览中的课程名称区域现在可以点击
- 点击后自动切换左侧到“全部”课程，并清除可能隐藏目标课程的筛选条件
- 使用课程号搜索课程，并根据课序号精确定位对应课程卡片
- 自动滚动到目标卡片，并通过短暂的蓝色动画高亮定位结果
- 为左侧课程卡片补充 `data-seq`，支持同课程号不同课序号的精确定位

## 交互兼容

- 课表右上角原有的 `✕` 移除操作保持不变
- 时间冲突单元格内的多门课程可以分别点击定位
- 当前已选、暂存和草稿课表预览共用该功能

## 验证

- 通过 `node --check src/render.js` 语法检查
- 通过 `git diff --check` 检查
- 本地扩展目录已应用相同修改，可重新加载扩展进行实际交互验证

Closes #23