### PR TITLE
功能：支持自定义时间占用并纳入冲突检测

### DIFF
--- a/content.css
+++ b/content.css
@@ -479,6 +479,15 @@
 .nx-tt td.nx-s { background: rgba(255,255,255,.75); backdrop-filter: saturate(160%) blur(12px); -webkit-backdrop-filter: saturate(160%) blur(12px); color: var(--nx-ink); font-weight: 600; box-shadow: inset 0 1px 0 rgba(255,255,255,.95), inset 0 0 0 1px rgba(47,107,255,.25); }
 .nx-tt td.nx-c { background: rgba(255,255,255,.75); backdrop-filter: saturate(160%) blur(12px); -webkit-backdrop-filter: saturate(160%) blur(12px); color: var(--nx-red); box-shadow: inset 0 1px 0 rgba(255,255,255,.95), inset 0 0 0 1px rgba(238,77,77,.3); }
 .nx-tt-cell { position: relative; }
+.nx-tt-manual { color: #7c3aed; }
+.nx-manual-form { display: grid; gap: 14px; }
+.nx-manual-form label { display: grid; gap: 6px; font-size: 12px; font-weight: 600; color: var(--nx-ink-soft); }
+.nx-manual-form .nx-inp { padding: 9px 12px; }
+.nx-manual-hint { font-size: 11px; color: var(--nx-faint); }
+.nx-manual-list { display: flex; align-items: center; flex-wrap: wrap; gap: 6px; margin-top: 10px; }
+.nx-manual-list-label { font-size: 11px; color: var(--nx-faint); }
+.nx-manual-chip { border: 0; border-radius: 999px; padding: 4px 10px; background: rgba(139,92,246,.12); color: #7c3aed; font-size: 11px; cursor: pointer; }
+.nx-manual-chip:hover { background: rgba(139,92,246,.2); }
 .nx-tt-text { display: block; font-size: 10px; line-height: 1.3; word-break: break-all; }
 .nx-tt-line { display: flex; flex-direction: column; align-items: center; gap: 2px; margin-bottom: 3px; }
 .nx-tt-line:last-child { margin-bottom: 0; }

--- a/content.js
+++ b/content.js
@@ -120,7 +120,7 @@ const HTML = `
       </div>
       <div class="nx-right">
         <div class="nx-sec"><div class="nx-sec-title">我的培养方案</div><div id="nextthuxk-plan" class="nx-plans"><div class="nx-st">等待加载…</div></div><div id="nextthuxk-plan-detail" style="margin-top:8px;font-size:12px;color:var(--nx-ink-soft)"></div></div>
-        <div class="nx-sec"><div class="nx-sec-title">课表预览 <span id="nextthuxk-preview-info" style="font-size:11px;color:var(--nx-ink-soft);font-weight:400"></span></div><div id="nextthuxk-preview-tt"><div class="nx-st">选课后自动生成预览</div></div><button class="nx-stage-btn" id="nextthuxk-preview-reset" style="display:none;margin-top:6px">返回当前已选课表</button></div>
+        <div class="nx-sec"><div class="nx-sec-title" style="display:flex;align-items:center;gap:8px">课表预览 <span id="nextthuxk-preview-info" style="font-size:11px;color:var(--nx-ink-soft);font-weight:400"></span><button class="nx-stage-btn" id="nextthuxk-add-manual" style="margin-left:auto">＋ 添加占用</button></div><div id="nextthuxk-preview-tt"><div class="nx-st">选课后自动生成预览</div></div><button class="nx-stage-btn" id="nextthuxk-preview-reset" style="display:none;margin-top:6px">返回当前已选课表</button></div>
         <div class="nx-sec">
           <div class="nx-sec-title">暂存课表</div>
           <div id="nextthuxk-stage-list"><div class="nx-st">暂无暂存课程</div></div>
@@ -201,6 +201,7 @@ NX.launch = async function launch() {
     if (g) state.GRADE = Math.max(1, Math.min(4, parseInt(g) || 0));
   }
   if (state.GRADE) await store.set('grade', state.GRADE);
+  state.manualEvents = (await store.get('manualEvents')) || [];
   const gradeBtn = $('nextthuxk-grade');
   if (gradeBtn) gradeBtn.textContent = state.GRADE ? ['', '大一', '大二', '大三', '大四'][state.GRADE] : '未设置';
   const listEl = $('nextthuxk-list');
@@ -506,6 +507,7 @@ $('nextthuxk-preview-stage').onclick = () => {
   state.previewMode = 'stage';
   renderPreviewTT(state.stageCart, '暂存区预览');
 };
+$('nextthuxk-add-manual').onclick = NX.showManualEventModal;
 $('nextthuxk-import').onclick = () => {
   const area = $('nextthuxk-import-area');
   if (area) area.style.display = area.style.display === 'none' ? 'block' : 'none';

--- a/src/config.js
+++ b/src/config.js
@@ -31,6 +31,7 @@ NX.state = {
   activeGroup: null,
   stageCart: [],
   savedDrafts: [],
+  manualEvents: [],
   queueDataMap: {},
   isQueuePhase: false,
   candidateCourses: [],

--- a/src/render.js
+++ b/src/render.js
@@ -297,13 +297,16 @@ NX.renderPreviewTT = function (courses, label) {
   if (resetBtn) resetBtn.style.display = (label && label !== '当前已选') ? 'inline-block' : 'none';
   state.previewMode = (label === '当前已选') ? 'selected' : 'stage';
   if (label && label.startsWith('草稿「')) state.previewMode = 'draft';
-  if (!courses.length) { el.innerHTML = '<div class="nx-st">暂无课程</div>'; return; }
+  const manualEvents = state.manualEvents || [];
+  if (!courses.length && !manualEvents.length) { el.innerHTML = '<div class="nx-st">暂无课程</div>'; return; }
   const tt = {};
   const undet = [];   // 时间未定/无固定时段课程（#16）：不进网格，单列在表格下方
-  courses.forEach((c, ci) => {
+  courses.concat(manualEvents).forEach((c, ci) => {
     const lbl = c.teacher ? c.name + '(' + c.teacher + ')' : c.name;
     let cellColor = '', probLabel = '', probBgColor = '';
-    if (isQueuePhase) {
+    if (c.manual) {
+      cellColor = '#8b5cf6'; probLabel = '自定义'; probBgColor = 'rgba(139,92,246,.14)';
+    } else if (isQueuePhase) {
       const qKey = c.code + '_' + (c.seq || '0');
       const qd = queueDataMap[qKey];
       const cand = candidateCourses.find(cc => cc.code === c.code && String(cc.seq) === String(c.seq || '0'));
@@ -327,11 +330,11 @@ NX.renderPreviewTT = function (courses, label) {
     const slots = parseTimeSlots(c.time);
     if (!slots.length) {
       // 时间未定/无固定时段（如二级选课阶段才定时间的实验课）→ 单列展示
-      undet.push({ lbl, ci, code: c.code, seq: c.seq || '0', credits: c.credits || 0, zy: c.zy || 0 });
+      undet.push({ lbl, ci, code: c.code, seq: c.seq || '0', credits: c.credits || 0, zy: c.zy || 0, manual: !!c.manual, id: c.id });
     }
     slots.forEach(({ day, slot }) => {
       if (!tt[day]) tt[day] = {};
-      const entry = { label: lbl, ci, code: c.code, seq: c.seq || '0', color: cellColor, probLabel, probBgColor };
+      const entry = { label: lbl, ci, code: c.code, seq: c.seq || '0', color: cellColor, probLabel, probBgColor, manual: !!c.manual, id: c.id };
       if (tt[day][slot]) {
         const old = tt[day][slot];
         const existing = old.conflict ? old.items : [old];
@@ -354,10 +357,10 @@ NX.renderPreviewTT = function (courses, label) {
       if (val) {
         const isC = val.conflict;
         const items = isC ? val.items : [val];
-        const btns = items.map(it => '<span class="nx-tt-rm" data-code="' + esc(it.code) + '" data-seq="' + esc(it.seq) + '" title="移除 ' + esc(it.label) + '">✕</span>').join('');
+        const btns = items.map(it => '<span class="nx-tt-rm" data-code="' + esc(it.code) + '" data-seq="' + esc(it.seq) + '"' + (it.manual ? ' data-manual-id="' + esc(it.id) + '"' : '') + ' title="移除 ' + esc(it.label) + '">✕</span>').join('');
         const linesHtml = items.map(it => {
           const probHtml = it.probLabel ? '<span class="nx-tt-prob" style="background:' + it.probBgColor + ';color:' + it.color + '">' + it.probLabel + '</span>' : '';
-          return '<div class="nx-tt-line"><span class="nx-tt-text">' + esc(it.label) + '</span>' + probHtml + '</div>';
+          return '<div class="nx-tt-line' + (it.manual ? ' nx-tt-manual' : '') + '"><span class="nx-tt-text">' + esc(it.label) + '</span>' + probHtml + '</div>';
         }).join('');
         let cellClass = isC ? 'nx-c' : 'nx-s';
         let cellStyle = '';
@@ -379,14 +382,27 @@ NX.renderPreviewTT = function (courses, label) {
         esc(u.lbl) + ' · ' + u.credits + '学分' + (u.zy ? ' · 第' + u.zy + '志愿' : '') + ' <i>✕</i></span>').join('') +
       '</div>';
   }
+  if (manualEvents.length) {
+    h += '<div class="nx-manual-list"><span class="nx-manual-list-label">自定义占用</span>' +
+      manualEvents.map(e => {
+        const slots = parseTimeSlots(e.time || '');
+        const when = slots.map(s => s.day + ' ' + s.slot).join('、');
+        return '<button type="button" class="nx-manual-chip" data-id="' + esc(e.id) + '" title="删除此占用">' + esc(e.name) + (when ? ' · ' + esc(when) : '') + '　✕</button>';
+      }).join('') + '</div>';
+  }
   const cr = courses.reduce((s, c) => s + (c.credits || 0), 0);
-  h += '<div class="nx-st ok" style="margin-top:6px">' + courses.length + '门课 · ' + cr + '学分</div>';
+  h += '<div class="nx-st ok" style="margin-top:6px">' + courses.length + '门课 · ' + cr + '学分' + (manualEvents.length ? ' · 自定义占用' + manualEvents.length + '项' : '') + '</div>';
   el.innerHTML = h;
   el.querySelectorAll('.nx-tt-rm').forEach(btn => {
-    btn.onclick = () => handlePreviewRemove(btn.dataset.code, btn.dataset.seq);
+    btn.onclick = () => btn.dataset.manualId
+      ? NX.removeManualEvent(btn.dataset.manualId)
+      : handlePreviewRemove(btn.dataset.code, btn.dataset.seq);
   });
   el.querySelectorAll('.nx-tt-undet').forEach(chip => {
     chip.onclick = () => handlePreviewRemove(chip.dataset.code, chip.dataset.seq);
+  });
+  el.querySelectorAll('.nx-manual-chip').forEach(chip => {
+    chip.onclick = () => NX.removeManualEvent(chip.dataset.id);
   });
 };
 

--- a/src/state.js
+++ b/src/state.js
@@ -30,7 +30,7 @@ NX.parseTimeSlots = function (timeStr) {
 NX.detectConflicts = function (courses) {
   const slotMap = {};
   const conflicts = [];
-  courses.forEach(c => {
+  courses.concat(NX.state.manualEvents || []).forEach(c => {
     NX.parseTimeSlots(c.time).forEach(({ day, slot }) => {
       const k = day + '|' + slot;
       if (slotMap[k]) conflicts.push({ day, slot, a: slotMap[k], b: c.name });
@@ -59,9 +59,11 @@ NX._pvRef = null; NX._pvLen = -1; NX._pvIdx = null;
 NX.invalidatePreview = function () { NX._pvRef = null; NX._pvLen = -1; NX._pvIdx = null; };
 NX.previewSlotIndex = function () {
   const previewCourses = NX.getPreviewCourses();
-  if (NX._pvRef !== previewCourses || NX._pvLen !== previewCourses.length) {
+  const manualEvents = NX.state.manualEvents || [];
+  const version = previewCourses.length + '|' + manualEvents.map(e => e.id + ':' + e.time).join(',');
+  if (NX._pvRef !== previewCourses || NX._pvLen !== version) {
     const idx = new Map();
-    previewCourses.forEach(pc => {
+    previewCourses.concat(manualEvents).forEach(pc => {
       NX.parseTimeSlots(pc.time || '').forEach(({ day, slot }) => {
         const k = day + '|' + slot;
         if (!idx.has(k)) idx.set(k, []);
@@ -69,10 +71,56 @@ NX.previewSlotIndex = function () {
       });
     });
     NX._pvRef = previewCourses;
-    NX._pvLen = previewCourses.length;
+    NX._pvLen = version;
     NX._pvIdx = idx;
   }
   return NX._pvIdx;
+};
+
+NX.showManualEventModal = function () {
+  const { state } = NX;
+  const $ = state.$;
+  const mask = $('nextthuxk-modal');
+  const title = $('nextthuxk-modal-title');
+  const body = $('nextthuxk-modal-body');
+  if (!mask || !title || !body) return;
+  title.textContent = '添加自定义时间占用';
+  body.innerHTML = '<div class="nx-manual-form">' +
+    '<label>活动名称<input id="nx-manual-name" class="nx-inp" placeholder="例如：社团例会"></label>' +
+    '<label>星期<select id="nx-manual-day" class="nx-inp"><option value="1">周一</option><option value="2">周二</option><option value="3">周三</option><option value="4">周四</option><option value="5">周五</option><option value="6">周六</option><option value="7">周日</option></select></label>' +
+    '<label>时间段<select id="nx-manual-slot" class="nx-inp"><option value="1">1-2节</option><option value="2">3-4节</option><option value="3">5-6节</option><option value="4">7-8节</option><option value="5">9-10节</option><option value="6">11-12节</option></select></label>' +
+    '<div class="nx-manual-hint">自定义占用会保存在本地，并参与课程冲突检测。</div>' +
+    '<button id="nx-manual-save" class="nx-ai-btn">添加到课表</button></div>';
+  mask.classList.add('show');
+  const nameInput = $('nx-manual-name');
+  nameInput.focus();
+  $('nx-manual-save').onclick = async () => {
+    const name = nameInput.value.trim();
+    if (!name) { NX.showXkResult({ ok: false, msg: '请输入活动名称' }); return; }
+    const now = Date.now();
+    const day = $('nx-manual-day').value;
+    const slot = $('nx-manual-slot').value;
+    state.manualEvents.push({ id: now, name, code: 'manual-' + now, seq: '0', time: day + '-' + slot + '(自定义)', manual: true, credits: 0 });
+    await NX.store.set('manualEvents', state.manualEvents);
+    NX.invalidatePreview();
+    NX.renderPreviewTT(NX.getPreviewCourses(), $('nextthuxk-preview-info')?.textContent || '当前已选');
+    NX.filterCourses();
+    mask.classList.remove('show');
+    NX.showXkResult({ ok: true, msg: '已添加「' + name + '」' });
+  };
+};
+
+NX.removeManualEvent = async function (id) {
+  const { state } = NX;
+  const idx = state.manualEvents.findIndex(e => String(e.id) === String(id));
+  if (idx < 0) return;
+  const name = state.manualEvents[idx].name;
+  state.manualEvents.splice(idx, 1);
+  await NX.store.set('manualEvents', state.manualEvents);
+  NX.invalidatePreview();
+  NX.renderPreviewTT(NX.getPreviewCourses(), state.$('nextthuxk-preview-info')?.textContent || '当前已选');
+  NX.filterCourses();
+  NX.showXkResult({ ok: true, msg: '已删除「' + name + '」' });
 };
 
 NX.findPreviewConflicts = function (course) {


### PR DESCRIPTION
## 修改内容

- 在“课表预览”标题栏增加“添加占用”入口
- 支持填写活动名称、星期和大节
- 自定义占用以紫色样式显示在课表网格中
- 自定义占用保存在扩展本地存储中，刷新页面后继续保留
- 在课表下方展示自定义占用列表，支持单独删除

## 冲突检测

- 将自定义占用加入预览课表的槽位索引
- 课程卡片可识别与社团活动等自定义占用的冲突
- “仅无冲突 / 仅冲突”筛选会考虑自定义占用
- 暂存课表和草稿课表的冲突检测会考虑自定义占用
- 当前已选、暂存和草稿三种预览模式都会显示自定义占用

## 安全性

该功能只读写扩展的 `storage.local`，不会调用选课、退选或候补接口，也不会修改教务系统中的真实课表。

## 验证

- 通过 `node --check` 检查 `content.js`、`src/config.js`、`src/state.js` 和 `src/render.js`
- 通过 `git diff --check` 检查
- 本地扩展目录已应用相同实现，可重新加载扩展进行交互验证

Closes #25