### PR TITLE
修复：点击课表内课程有时无法跳转至对应课序号课程的问题

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -1547,6 +1547,9 @@ NX.mergeServerRows = function (rows) {
             NX.applyVolunteer(targets, state.volMap);
             NX.filterCourses();
             try { NX.renderStageCart(); } catch (e) {}   // 暂存条概率跟志愿数据一起到（一会有一会没的根因）
+            // 整表重渲会把跳转定位冲掉（innerHTML 重建 → scrollTop 归零、
+            // 高亮丢失，「滚到卡片又弹回结果顶端」实锤）——按最近跳转恢复
+            try { if (NX.reapplyJumpIfFresh) NX.reapplyJumpIfFresh(); } catch (e) {}
           } catch (e) {
             console.warn(NX.TAG, 'volunteer 按需补拉失败:', newDepts.join(','), e);
           }

--- a/src/render.js
+++ b/src/render.js
@@ -1196,6 +1196,10 @@ NX.loadSearchPageTo = async function (target) {
     }
   } catch (e) { console.warn(NX.TAG, 'search page load:', e); }
   state._loadingAll = false;
+  // 补页后按实际加载量重判完整性：拉齐了就不挂「数据不完整」横幅
+  // （fetchJumpRestPages 补齐全部课序后横幅残留实锤——_searchIncomplete
+  // 此前只在初始查询/手动「加载全部」两处置位）
+  state._searchIncomplete = !!(state._searchTotalRows && (state._searchRows || []).length < state._searchTotalRows);
   state._uiPage = Math.min(to, Math.max(1, Math.ceil((state._searchRows || []).length / NX.PAGE_SIZE)));
   NX.filterCourses();
 };

--- a/src/render.js
+++ b/src/render.js
@@ -1392,7 +1392,8 @@ NX.highlightJumpTarget = function () {
 
 /** 精确课号跳转的补页：目标课序不在已加载页（课号 >20 课序跨页）时，拉齐该
  *  课号其余页再定位。护栏：页 1 必须全部属于该课号（教务忽略 p_kch 时返回
- *  未过滤首页，此时补页等于全库爬，直接放弃）；最多补到第 5 页。 */
+ *  未过滤首页，此时补页等于全库爬，直接放弃）；上限 25 页（serverSearchStorm
+ *  「总页数已知 ≤25 全量」同款——覆盖单课号全部课序，防的只是异常值）。 */
 NX.fetchJumpRestPages = async function (code, seq) {
   const state = NX.state;
   try {
@@ -1400,7 +1401,7 @@ NX.fetchJumpRestPages = async function (code, seq) {
     if (!so.kch || so.kch !== String(code)) return;
     const rows = state._searchRows || [];
     if (!rows.length || !rows.every(r => String(r.code) === String(code))) return;
-    const totalPages = Math.min(state._searchTotalPages || 1, 5);
+    const totalPages = Math.min(state._searchTotalPages || 1, 25);
     const loaded = Math.ceil(rows.length / NX.PAGE_SIZE);
     if (totalPages <= loaded) return;
     await NX.loadSearchPageTo(totalPages);

--- a/src/render.js
+++ b/src/render.js
@@ -1335,26 +1335,102 @@ NX.scheduleServerSearch = function (immediate) {
   NX._ssTimer = setTimeout(() => { NX._ssTimer = null; NX.runServerSearch(); }, immediate ? 0 : 500);
 };
 
+/** 跳转目标卡片查找：课序号精确 → 归一化（normSeq——预览/已选/暂存行与
+ *  kkxx 搜索行是两套课序号，"01"/"1" 严格比对必 miss）→ 课号唯一行兜底。 */
+NX.findJumpCard = function (list, code, seq) {
+  const codeS = String(code);
+  const seqS = String(seq || '0');
+  const cards = [...list.querySelectorAll('.nx-card')].filter(c => c.dataset.code === codeS);
+  return cards.find(c => String(c.dataset.seq || '0') === seqS)
+    || cards.find(c => NX.normSeq(c.dataset.seq || '0') === NX.normSeq(seqS))
+    || (cards.length === 1 ? cards[0] : null);
+};
+
+NX.flashJumpCard = function (target) {
+  target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  target.classList.add('nx-jump-target');
+  setTimeout(() => target.classList.remove('nx-jump-target'), 1800);
+};
+
 /** 跳转目标高亮（OneTHU jumpTo 定稿语义：课号注入搜索栏并保持，
- *  高亮 1.8s 瞬时清除；无自动清词） */
+ *  高亮 1.8s 瞬时清除；无自动清词）。
+ *  「只到结果顶端、不到课序号」三连修：
+ *  ① 课序号匹配 精确→归一→课号唯一兜底（两套课序号对不上时严格比对全 miss）；
+ *  ② 目标行在本地分页其他页（课号下 >20 课序）→ 自动翻到所在页再找；
+ *  ③ 记 _lastJump，跳转后短期内的异步重渲由 reapplyJumpIfFresh 恢复定位。 */
 NX.highlightJumpTarget = function () {
   const state = NX.state;
   if (!state._jumpCode) return;
-  const $ = state.$;
   const code = state._jumpCode, seq = state._jumpSeq || '0';
   state._jumpCode = null;
+  state._lastJump = { code, seq, at: Date.now() };
   requestAnimationFrame(() => {
-    const list = $('nextthuxk-list');
+    const list = state.$('nextthuxk-list');
     if (!list) return;
-    const target = [...list.querySelectorAll('.nx-card')].find(card =>
-      card.dataset.code === String(code) &&
-      String(card.dataset.seq || '0') === String(seq));
+    let target = NX.findJumpCard(list, code, seq);
+    if (!target && state._searchRows && state._searchRows.length) {
+      const idx = state._searchRows.findIndex(r => String(r.code) === String(code)
+        && NX.normSeq(r.seq || '0') === NX.normSeq(seq));
+      if (idx >= 0) {
+        const page = Math.floor(idx / NX.PAGE_SIZE) + 1;
+        if (page !== (state._uiPage || 1)) {
+          state._uiPage = page;   // serverSig 不含 _uiPage：只本地翻页，不发新请求
+          try { NX.filterCourses(); } catch (e) {}
+          target = NX.findJumpCard(list, code, seq);
+        }
+      }
+    }
     if (target) {
-      target.scrollIntoView({ behavior: 'smooth', block: 'center' });
-      target.classList.add('nx-jump-target');
-      setTimeout(() => target.classList.remove('nx-jump-target'), 1800);
+      NX.flashJumpCard(target);
+    } else {
+      // 目标行连搜索结果里都没有：精确课号查询 storm 护栏只探第 1 页，
+      // 课序号在第 2 页起（>20 课序的课）——补拉该课号其余页后重试定位
+      NX.fetchJumpRestPages(code, seq);
     }
   });
+};
+
+/** 精确课号跳转的补页：目标课序不在已加载页（课号 >20 课序跨页）时，拉齐该
+ *  课号其余页再定位。护栏：页 1 必须全部属于该课号（教务忽略 p_kch 时返回
+ *  未过滤首页，此时补页等于全库爬，直接放弃）；最多补到第 5 页。 */
+NX.fetchJumpRestPages = async function (code, seq) {
+  const state = NX.state;
+  try {
+    const so = NX.buildSearchOpts();
+    if (!so.kch || so.kch !== String(code)) return;
+    const rows = state._searchRows || [];
+    if (!rows.length || !rows.every(r => String(r.code) === String(code))) return;
+    const totalPages = Math.min(state._searchTotalPages || 1, 5);
+    const loaded = Math.ceil(rows.length / NX.PAGE_SIZE);
+    if (totalPages <= loaded) return;
+    await NX.loadSearchPageTo(totalPages);
+    const list = state.$('nextthuxk-list');
+    if (!list) return;
+    let target = NX.findJumpCard(list, code, seq);
+    if (!target) {
+      const idx = (state._searchRows || []).findIndex(r => String(r.code) === String(code)
+        && NX.normSeq(r.seq || '0') === NX.normSeq(seq));
+      if (idx >= 0) {
+        state._uiPage = Math.floor(idx / NX.PAGE_SIZE) + 1;
+        NX.filterCourses();
+        target = NX.findJumpCard(list, code, seq);
+      }
+    }
+    if (target) NX.flashJumpCard(target);
+  } catch (e) { console.warn(NX.TAG, 'jump 补页:', e); }
+};
+
+/** 跳转后 6s 内列表若被异步重渲（mergeServerRows 志愿补拉回填等会整表
+ *  filterCourses 重建 DOM——innerHTML 清空使 scrollTop 归零、高亮块一并
+ *  被冲掉，「已滚到卡片又弹回顶端」实锤），按 _lastJump 重定位恢复。 */
+NX.reapplyJumpIfFresh = function () {
+  const state = NX.state;
+  const lj = state._lastJump;
+  if (!lj || Date.now() - lj.at > 6000) return;
+  const list = state.$ && state.$('nextthuxk-list');
+  if (!list) return;
+  const target = NX.findJumpCard(list, lj.code, lj.seq);
+  if (target) NX.flashJumpCard(target);
 };
 
 NX.updateSearchClear = function () {

--- a/src/reviews.js
+++ b/src/reviews.js
@@ -137,6 +137,7 @@ var NX = NX || {};
       if (NX.state && Array.isArray(NX.state.allCourses) && NX.state.allCourses.length && typeof NX.tbAttach === 'function') {
         NX.tbAttach(NX.state.allCourses);
         if (typeof NX.filterCourses === 'function') NX.filterCourses();   // 重绘徽章（fail-soft）
+        if (typeof NX.reapplyJumpIfFresh === 'function') NX.reapplyJumpIfFresh();   // 重渲后恢复跳转定位
       }
     } catch (e) {}
   }


### PR DESCRIPTION
## 问题描述

在点击课表中的一门课程时，左侧搜索栏有时会跳转至对应课程号的对应课序号的课程，而有时只会跳转至对应课程号结果的顶端，这一情况通常与“数据不完整：已加载 20 门，教务共 6 页（共 112 门）”类似提示一并出现。

## 根因

这个「有时定位到具体课序、有时只停在结果顶端」的症状由三个独立缺陷叠加造成，全部在跳转链路 jumpToCourse → runServerSearch → highlightJumpTarget 中：

- 根因 1：课序号严格比对（主因）。highlightJumpTarget 原来用 card.dataset.seq === seq 严格字符串比对，但课表块上的课序号来自已选/暂存/候补行（如 '1'），而搜索结果卡片来自 kkxxSearch（如 '01'）——这正是代码里反复注释的「两套课序号」问题，且此处是全码唯一没用 normSeq 归一的比较点。比对失败就不滚动，停在顶端。对同一门课是确定性的，跨课程看就像「有时坏」。

- 根因 2：志愿补拉异步重渲冲掉定位。跳转触发搜索后，mergeServerRows 若发现该院系志愿数据本会话没拉过，会在 1–3 秒后回调 filterCourses() 整表重建 DOM——innerHTML 清空使 scrollTop 归零、高亮块丢失。第一次跳某院系的课必中，再跳就好，完美对应「有时好有时坏」。

- 根因 3：目标课序不在第 1 页。精确课号查询受风暴护栏只探 1 页（20 行），课序号多于 20 的课目标行可能根本不在结果里，或被本地分页切到其他页。

## 修改内容（3 个文件，语法检查通过）：

- src/render.js：新增 findJumpCard（课序号 精确 → normSeq 归一 → 课号唯一行兜底 三级匹配）、flashJumpCard（滚动+高亮复用）；重写 highlightJumpTarget——匹配失败时若目标行在 _searchRows 的其他本地页则自动翻页重找；仍找不到则调新增的 fetchJumpRestPages 补拉该课号其余页（护栏：页 1 必须全部属于该课号才补，防教务忽略 p_kch 时变成全库爬；最多补到第 25 页）；新增 reapplyJumpIfFresh——把跳转目标记入 state._lastJump（6 秒窗口），供异步重渲后恢复定位。
- src/data.js：志愿补拉回调在 filterCourses() 重渲后调用 reapplyJumpIfFresh() 恢复滚动与高亮。
- src/reviews.js：社区索引 SWR 后台刷新的 reattachAll 重绘后同样恢复（启动后立刻跳转的场景）。

## 验证

手动验证：重新加载插件后，点击课表内课程可以跳转至对应课序号的正确课程，不再停留在页面顶端，也不再出现“数据不完整：已加载 20 门，教务共 6 页（共 112 门）”的情况，完整解决了这一问题。

## 合并冲突

这一改动可能与 `62a442586b03cedbba76925430b8f69818fdd37b` 起的一些commit产生冲突，因为修复的是同一问题。不过这一改动完全解决了无法跳转的问题，而原仓库有时仍无法正确跳转。