### PR TITLE
feat.修改草稿修改与批量选课逻辑，对已选课优先计算概率并快速展示

### DIFF
--- a/content.js
+++ b/content.js
@@ -345,9 +345,50 @@ NX.launch = async function launch() {
         // （OneTHU dev 的 getXkVolunteer 是死码——这里真接上；池内逐门单查，
         // 绝不整库硬爬）
         try {
-          const vol = await NX.fetchVolunteer(pool);
-          state.volMap = Object.assign({}, state.volMap, vol);   // 全局持久：搜索/跳转新行可取
+          // 已选课概率优先（准备阶段已选的课进入工作台即快速可算）：
+          // onData 增量回调——每拉完一个院系立即合并 volMap + 全量重放 + 重渲，
+          // 已选课院系在拉取队列最前（池序），卡片逐院系点亮，不再等全部
+          // 院系串行扫完（10-20s+）才一次性上屏
+          const vol = await NX.fetchVolunteer(pool, {
+            onData: m => {
+              state.volMap = Object.assign({}, state.volMap, m);   // 全局持久：搜索/跳转新行可取
+              NX.applyVolunteer(pool, state.volMap);
+              NX.filterCourses();
+              try { NX.renderStageCart(); } catch (e) {}   // 暂存条概率同步点亮
+            },
+          });
+          state.volMap = Object.assign({}, state.volMap, vol);
           NX.applyVolunteer(pool, vol);
+          // 已选课缺行自愈：院系页缺行/错页（070 分院视图缺行等）导致 volMap
+          // 仍缺的已选课，逐课号 p_kch 定向补拉（fetchVolCourse，每课 1-2 请求）；
+          // 每课号每会话只试一次——正常情况零请求，绝不整库硬爬
+          if (state.isZhjwxk) {
+            const tried = state._selVolTried || (state._selVolTried = {});
+            const seenC = new Set();
+            const missing = [];
+            pool.forEach(c => {
+              if (!c.code || seenC.has(c.code) || tried[c.code]) return;
+              seenC.add(c.code);
+              tried[c.code] = 1;
+              if (!(state.volMap || {})[c.code + '_' + NX.normSeq(c.seq)]) missing.push(c.code);
+            });
+            if (missing.length) {
+              await NX.runPool(missing, 3, async code => {
+                try {
+                  const m2 = await NX.fetchVolCourse(code);
+                  if (Object.keys(m2).length) {
+                    state.volMap = Object.assign({}, state.volMap, m2);
+                    // 全量 volMap 重放（applyVolunteer else 分支会无条件清空——
+                    // 拿增量套会洗掉兄弟课序行已上屏的志愿数据，mergeServerRows 定案）
+                    NX.applyVolunteer(pool.filter(x => x.code === code), state.volMap);
+                  }
+                } catch (e2) { console.warn(TAG, '已选课志愿定向补拉', code, e2); }
+              });
+              NX.filterCourses();
+              try { NX.renderStageCart(); } catch (e) {}
+              console.log(TAG, '已选课志愿缺行定向补拉:', missing.length, '课号');
+            }
+          }
         } catch (e) { console.warn(TAG, 'volunteer:', e); }
       }
       const qBtn = state.$('nextthuxk-phase-tag');

--- a/src/data.js
+++ b/src/data.js
@@ -330,6 +330,10 @@ NX.fetchCourseCatalog = async function () {
 // 拉取策略 = 实时院系定向：池内课程按院系去重 → 逐院系 GET
 //   （v1.5.0 同款：首页无 page 无 token，翻页 &page=N）→ 院系内分页
 //   通常 1-3 页。搜索结果行遇到未拉院系按需补拉（防抖、不重拉）。
+// 增量回调（opts.onData，已选课概率优先）：逐院系扫描时每拉完一个院系
+//   （错页校验通过）即回调一次，传全量累积 map——调用方立即合并 volMap +
+//   applyVolunteer 全量重放 + 重渲，已选课卡片不等整轮扫完逐院系点亮
+//   （原先全部院系拉完才一次性上屏 10-20s+ → 首院系 1-2s 即现）。Ty 同。
 // 阶段门控：仅非队列阶段（预选/志愿期）——队列阶段概率走排队/余量模型。
 NX.DEPT_CODES = {
   '建筑学院': '000',
@@ -460,6 +464,7 @@ NX.fetchVolunteer = async function (courses, opts) {
   if (!state.isZhjwxk) return {};
   const { SEM, BASE } = state;
   const force = !!(opts && opts.force);
+  const onData = (opts && opts.onData) || null;   // 增量回调：每院系落地即通知（传全量累积 map）
   const done = state._volDepts || (state._volDepts = {});   // 本会话已拉院系（refreshSelected 用 force 重拉）
   const pool = (courses || []).filter(c => c && c.code && !c.isCandidate);
   const map = {};
@@ -501,6 +506,7 @@ NX.fetchVolunteer = async function (courses, opts) {
       items.forEach(v => { map[v.code + '_' + NX.normSeq(v.seq)] = v; });   // 键归一（前导0课序）
       done[code] = Date.now();
       fetched.push(code);
+      if (onData) { try { onData(map); } catch (e) { console.warn(NX.TAG, 'volunteer onData:', e); } }
     } catch (e) { console.warn(NX.TAG, 'volunteer dept ', code, e); }
   }
   // Ty：体育志愿（无院系轴，全量 ≤20 页；force 重拉）
@@ -524,6 +530,7 @@ NX.fetchVolunteer = async function (courses, opts) {
           { capacity: 0, applied: 0, volRequired: '', volElective: '', volOptional: '' }, map[k], v);
       });
       done.ty = Date.now();
+      if (onData) { try { onData(map); } catch (e) { console.warn(NX.TAG, 'volunteer onData:', e); } }
     } catch (e) { console.warn(NX.TAG, 'volunteer Ty:', e); }
   }
   console.log(NX.TAG, 'volunteer (dept-sync): ', Object.keys(map).length, 'entries, depts', fetched.join(',') || '(无新院系)');

--- a/src/render.js
+++ b/src/render.js
@@ -925,7 +925,21 @@ NX.renderDrafts = function () {
     btn.onclick = () => {
       const idx = parseInt(btn.dataset.idx);
       const d = savedDrafts[idx];
-      if (d) { state.previewDraftIdx = idx; renderPreviewTT(d.courses, '草稿「' + d.name + '」预览'); }
+      if (!d) return;
+      const stageCart = state.stageCart;
+      const same = stageCart.length === d.courses.length && stageCart.every(s => d.courses.some(c => c.code === s.code && String(c.seq || '0') === String(s.seq || '0')));
+      if (stageCart.length && !same && !confirm('暂存区已有 ' + stageCart.length + ' 门课程，载入草稿「' + d.name + '」将替换它们，继续？')) {
+        renderPreviewTT(d.courses, '草稿「' + d.name + '」预览');
+        return;
+      }
+      state.stageCart = d.courses.map(c => ({ ...c, seq: c.seq || '0', flag: c.flag || 'bx', zy: c.zy || 3 }));
+      store.set('stageCart', state.stageCart);
+      NX.invalidatePreview();
+      state.previewDraftIdx = -1;
+      NX.renderStageCart();
+      NX.filterCourses();
+      renderPreviewTT(state.stageCart, '暂存区预览');
+      NX.showXkResult({ ok: true, msg: '草稿「' + d.name + '」已载入暂存区，可直接修改' });
     };
   });
   el.querySelectorAll('.nx-draft-go').forEach(btn => {

--- a/src/render.js
+++ b/src/render.js
@@ -946,8 +946,7 @@ NX.renderDrafts = function () {
     btn.onclick = () => {
       const d = savedDrafts[parseInt(btn.dataset.idx)];
       if (!d) return;
-      if (!confirm('确定提交「' + d.name + '」？\n将先退选所有已选课程，再选入该草稿中的 ' + d.courses.length + ' 门课程。')) return;
-      promoteDraft(d);
+      promoteDraft(d);   // 确认由 promoteDraft 内差量明细+终确认两级弹窗承担
     };
   });
   el.querySelectorAll('.nx-draft-del').forEach(btn => {

--- a/src/state.js
+++ b/src/state.js
@@ -740,48 +740,66 @@ NX.importToStage = function (jsonStr) {
 };
 
 NX.promoteDraft = async function (draft) {
-  const { state, showXkResult, fetchSelectedCourses, dropCourse, submitCourse, refreshSelected, renderPreviewTT, confirmDrop } = NX;
+  const { state, showXkResult, fetchSelectedCourses, fetchCandidateCourses, dropCourse, submitCourse, refreshSelected, renderPreviewTT } = NX;
   const $ = state.$;
   const toast = $('nextthuxk-toast');
   const prog = (msg) => { if (toast) { toast.className = 'nx-toast'; toast.style.cssText = 'display:block;opacity:1;background:rgba(29,31,36,.82);backdrop-filter:blur(20px) saturate(180%);-webkit-backdrop-filter:blur(20px) saturate(180%);color:#fff'; toast.textContent = msg; } };
   try {
-    prog('正在获取已选课程…');
+    prog('正在获取已选与候补课程…');
     const current = await fetchSelectedCourses();
-    // ── 差分提交（OneTHU 同款）：绝不「全退再全选」。补退选窗口中途失败
-    //    会留下半张课表（已退的抢不回来）。code+seq 双键比对分三桶：
-    //    保留（交集，不碰）/ 新选（草稿有、当前无）/ 退掉（当前有、草稿无）。
-    //    顺序铁律：先选后退——最坏情况新课没选上但旧课全在（回到提交前
-    //    原状可重试），永不劣于提交前状态。
-    const key = (code, seq) => code + '_' + String(seq || '0');
-    const wantKeys = new Set(draft.courses.map(c => key(c.code, c.seq)));
-    const haveKeys = new Set(current.map(c => key(c.code, c.seq)));
-    const toAdd = draft.courses.filter(c => !haveKeys.has(key(c.code, c.seq)));
-    const toDrop = current.filter(c => !wantKeys.has(key(c.code, c.seq)));
-    const kept = draft.courses.length - toAdd.length;
-    if (!toAdd.length && !toDrop.length) {
-      showXkResult({ ok: true, msg: '「' + draft.name + '」与当前已选完全一致，无需提交' });
+    const cand = await fetchCandidateCourses();
+    state.candidateCourses = cand;   // dropCourse 靠此列表路由退队(dlDelete)/退选(deleteYxk)路径
+    // 差量比对（课号+课序号，前导零归一）：相同保留不动，多余已选退选、多余候补退队，只选入缺失草稿课
+    const keyOf = c => c.code + '_' + NX.normSeq(c.seq || '0');
+    const draftKeys = new Set(draft.courses.map(keyOf));
+    const toDropSel = current.filter(c => !draftKeys.has(keyOf(c)));
+    const dropSelKeys = new Set(toDropSel.map(keyOf));
+    const toDropQueue = cand.filter(c => !draftKeys.has(keyOf(c)) && !dropSelKeys.has(keyOf(c)));
+    const merged = current.concat(cand);
+    const existKeys = new Set(merged.map(keyOf));
+    const toSubmit = draft.courses.filter(c => !existKeys.has(keyOf(c)));
+    if (!toDropSel.length && !toDropQueue.length && !toSubmit.length) {
+      await refreshSelected();
+      showXkResult({ ok: true, msg: '草稿「' + draft.name + '」与当前课表一致，无需提交' });
       return;
     }
-    // 退课逐门二次确认（玻璃警告弹窗）——用户令：有人没意识到退选是真退
-    for (const c of toDrop) {
-      const go = await confirmDrop(c.name, c.code + '_' + String(c.seq || '0'));
-      if (!go) {
-        prog('已取消：' + c.name + ' 不退选，提交中止（已执行部分不受影响）');
-        break;
-      }
-      prog('退选 ' + c.name + '…');
-      await dropCourse(c.code, c.seq);
+    const nameOf = c => (c.name || c.code) + ' (' + c.code + '_' + (c.seq || '0') + ')';
+    const section = (title, arr) => ['· ' + title + ' ' + arr.length + ' 门：'].concat(arr.map((c, i) => '  ' + (i + 1) + '. ' + nameOf(c)));
+    const keptCount = new Set(merged.filter(c => draftKeys.has(keyOf(c))).map(keyOf)).size;
+    const lines = ['草稿「' + draft.name + '」与当前选课状态比对：', '· 保留（已选/候补已有）' + keptCount + ' 门'];
+    if (toDropSel.length) lines.push(...section('将退选', toDropSel));
+    if (toDropQueue.length) lines.push(...section('将退出候补', toDropQueue));
+    if (toSubmit.length) lines.push(...section('将选入', toSubmit));
+    lines.push('确认提交？');
+    if (!confirm(lines.join('\n'))) return;
+    const acts = [];
+    if (toDropSel.length) acts.push('退选 ' + toDropSel.length + ' 门');
+    if (toDropQueue.length) acts.push('退出候补 ' + toDropQueue.length + ' 门');
+    if (toSubmit.length) acts.push('选入 ' + toSubmit.length + ' 门');
+    if (!confirm('二次确认：即将' + acts.join('、') + '。\n执行过程中请勿关闭或刷新页面。确认开始执行？')) return;
+    for (let i = 0; i < toDropSel.length; i++) {
+      prog('退选 ' + (i + 1) + '/' + toDropSel.length + ': ' + (toDropSel[i].name || toDropSel[i].code));
+      await dropCourse(toDropSel[i].code, toDropSel[i].seq);
       await new Promise(r => setTimeout(r, 1000));
     }
-    for (let i = 0; i < toAdd.length; i++) {
-      const c = toAdd[i];
-      prog('新选 ' + (i + 1) + '/' + toAdd.length + ': ' + c.name);
+    for (let i = 0; i < toDropQueue.length; i++) {
+      prog('退队 ' + (i + 1) + '/' + toDropQueue.length + ': ' + (toDropQueue[i].name || toDropQueue[i].code));
+      await dropCourse(toDropQueue[i].code, toDropQueue[i].seq);
+      await new Promise(r => setTimeout(r, 1000));
+    }
+    for (let i = 0; i < toSubmit.length; i++) {
+      const c = toSubmit[i];
+      prog('选课 ' + (i + 1) + '/' + toSubmit.length + ': ' + (c.name || c.code));
       await submitCourse(c.code, c.seq, c.zy || 3, c.flag || 'bx');
       // 排队选课内部已有 1.5s 延时，这里额外等 2s 避免触发验证码
       await new Promise(r => setTimeout(r, 2000));
     }
     await refreshSelected();
-    showXkResult({ ok: true, msg: '「' + draft.name + '」差分提交完成：新选 ' + toAdd.length + '、退掉 ' + toDrop.length + '、保留 ' + kept });
+    const done = [];
+    if (toDropSel.length) done.push('退选' + toDropSel.length);
+    if (toDropQueue.length) done.push('退队' + toDropQueue.length);
+    if (toSubmit.length) done.push('选入' + toSubmit.length);
+    showXkResult({ ok: true, msg: '课表「' + draft.name + '」已提交（' + done.join('·') + '）！' });
     const sel = state.allCourses.filter(c => c.selected);
     renderPreviewTT(sel, '当前已选');
   } catch (e) { showXkResult({ ok: false, msg: '提交出错（已执行部分不回滚）: ' + e.message }); }


### PR DESCRIPTION
### **修改内容**

- 草稿预览&修改逻辑，将需要修改的草稿自动划入暂存区
- 使用草稿批量选课时，将草稿数据与已选/预选数据进行比较后进行退课/退选与选课操作，并添加二次确认
- 对于已选课程，优先获取数据并计算概率，并且尽早出现在已选课表中

### **安全性**

- 批量选课可能出现异常，因现在无法进行选课，无法测试逻辑完整性

### **检测**

- 通过 `node --check` 检查 `content.js`、`src/data.js`、`src/state.js` 和 `src/render.js`
- 通过 `git diff --check` 检查
- 本地扩展目录已应用相同实现，可重新加载扩展进行交互验证